### PR TITLE
strip whitespace on coupon code validation

### DIFF
--- a/scalereg/reg6/views.py
+++ b/scalereg/reg6/views.py
@@ -1482,7 +1482,7 @@ def RedeemCoupon(request):
     return r
 
   try:
-    coupon = models.Coupon.objects.get(code=request.POST['code'])
+    coupon = models.Coupon.objects.get(code=request.POST['code'].strip())
   except models.Coupon.DoesNotExist:
     return scale_render_to_response(request, 'reg6/reg_error.html',
       {'title': 'Registration Problem',


### PR DESCRIPTION
Attendees frequently copy coupon codes from email or other sources, along with unnecessary spaces.
Lets strip these to reduce support pains.