### PR TITLE
Change Lookup page to use a Django Form

### DIFF
--- a/scalereg3/reg23/forms.py
+++ b/scalereg3/reg23/forms.py
@@ -18,3 +18,13 @@ class AttendeeForm(ModelForm):
             'phone',
             'can_email',
         )
+
+
+class AttendeeLookupForm(ModelForm):
+
+    class Meta:
+        model = models.Attendee
+        fields = (
+            'email',
+            'zip_code',
+        )

--- a/scalereg3/reg23/templates/reg23/reg_lookup.html
+++ b/scalereg3/reg23/templates/reg23/reg_lookup.html
@@ -8,10 +8,20 @@
     <hr />
 
     <p>
-    {% if email and zip %}
-        Search results for: {{ email }} and {{ zip }}.
+    {% if form.is_valid %}
+        Search results for: {{ form.data.email }} and {{ form.data.zip_code }}.
     {% else %}
         Please fill out all required fields to search.
+        {% if form.email.errors %}
+        <p class="reg23_form_error">
+            Email: {{ form.email.errors|join:", " }}
+        </p>
+        {% endif %}
+        {% if form.zip_code.errors %}
+        <p class="reg23_form_error">
+            Zip/Postal Code: {{ form.zip_code.errors|join:", " }}
+        </p>
+        {% endif %}
     {% endif %}
     </p>
 
@@ -54,11 +64,11 @@ Use this form to look up existing registrations. All fields are required.
 <table>
 <tr>
     <td>Email</td>
-    <td><input type="text" name="email" maxlength="75" size="50" /></td>
+    <td>{{ form.email }}</td>
 </tr>
 <tr>
     <td>Zip/Postal Code</td>
-    <td><input type="text" name="zip" maxlength="10" size="10" /></td>
+    <td>{{ form.zip_code }}</td>
 </tr>
 </table>
 <input type="submit" class="scale_kiosk_bordered" value="Search" />

--- a/scalereg3/reg23/tests.py
+++ b/scalereg3/reg23/tests.py
@@ -1778,16 +1778,17 @@ class RegLookupTest(TestCase):
 
     def test_post_request_no_data(self):
         response = self.client.post('/reg23/reg_lookup/', {})
-        self.assertContains(response, 'No email information.')
+        self.assertContains(response, 'Email: This field is required.')
 
     def test_post_request_no_zip(self):
         response = self.client.post('/reg23/reg_lookup/', {'email': 'a@a.com'})
-        self.assertContains(response, 'No zip information.')
+        self.assertContains(response,
+                            'Zip/Postal Code: This field is required.')
 
     def test_post_request_attendee_not_found(self):
         response = self.client.post('/reg23/reg_lookup/', {
             'email': 'no@no.com',
-            'zip': '54321'
+            'zip_code': '54321'
         })
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'First Last')
@@ -1795,7 +1796,7 @@ class RegLookupTest(TestCase):
     def test_post_request_attendee_found(self):
         response = self.client.post('/reg23/reg_lookup/', {
             'email': 'a@a.com',
-            'zip': '12345'
+            'zip_code': '12345'
         })
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'First Last')
@@ -1803,7 +1804,7 @@ class RegLookupTest(TestCase):
     def test_post_request_attendee_found_with_spaces(self):
         response = self.client.post('/reg23/reg_lookup/', {
             'email': 'a@a.com ',
-            'zip': '  12345    '
+            'zip_code': '  12345    '
         })
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'First Last')
@@ -1811,7 +1812,7 @@ class RegLookupTest(TestCase):
     def test_post_request_wrong_email(self):
         response = self.client.post('/reg23/reg_lookup/', {
             'email': 'wrong@email.com',
-            'zip': '12345'
+            'zip_code': '12345'
         })
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'First Last')
@@ -1819,7 +1820,7 @@ class RegLookupTest(TestCase):
     def test_post_request_wrong_zip(self):
         response = self.client.post('/reg23/reg_lookup/', {
             'email': 'a@a.com',
-            'zip': 'wrong'
+            'zip_code': 'wrong'
         })
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'First Last')

--- a/scalereg3/reg23/views.py
+++ b/scalereg3/reg23/views.py
@@ -7,7 +7,6 @@ from django.shortcuts import redirect
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 
-
 from common import utils
 
 from . import forms
@@ -582,28 +581,20 @@ def reg_lookup(request):
     if request.method != 'POST':
         return render(request, 'reg23/reg_lookup.html', {
             'title': 'Registration Lookup',
+            'form': forms.AttendeeLookupForm()
         })
 
-    required_vars = (
-        'email',
-        'zip',
-    )
-    r = check_vars(request, required_vars)
-    if r:
-        return r
-
     attendees = []
-    email_str = request.POST['email'].strip()
-    zip_str = request.POST['zip'].strip()
-    if email_str and zip_str:
-        attendees = models.Attendee.objects.filter(email=email_str,
-                                                   zip_code=zip_str)
+    form = forms.AttendeeLookupForm(request.POST)
+    if form.is_valid():
+        attendees = models.Attendee.objects.filter(
+            email=form.cleaned_data['email'],
+            zip_code=form.cleaned_data['zip_code'])
 
     return render(
         request, 'reg23/reg_lookup.html', {
             'title': 'Registration Lookup',
             'attendees': attendees,
-            'email': request.POST['email'],
-            'zip': request.POST['zip'],
+            'form': form,
             'search': 1,
         })


### PR DESCRIPTION
Instead of manually adding form fields in reg_lookup.html, use Django Forms instead. As a result:

1. The form fields will render based on the Attendee Model and not have discrepancies such as maxlength mismatches.
2. The results page can give better error messages.
3. This requires less code to manually parse and clean the POST data.

Make minor updates to tests to match the new input/output.