### PR TITLE
Add sales dashboard

### DIFF
--- a/scalereg3/reports/apps.py
+++ b/scalereg3/reports/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class ReportsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'reports'

--- a/scalereg3/reports/templates/reports_index.html
+++ b/scalereg3/reports/templates/reports_index.html
@@ -1,0 +1,23 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block coltype %}colMS{% endblock %}
+{% block bodyclass %}dashboard{% endblock %}
+{% block content %}
+<div id="content-main">
+
+{% if model_list %}
+    <div class="module">
+    <table>
+    {% for model in model_list %}
+        <tr>
+            <th scope="row"><a href="{{ model.url }}">{{ model.name }}</a></th>
+        </tr>
+    {% endfor %}
+    </table>
+    </div>
+{% else %}
+    <p>{% trans "You don't have permission to view anything." %}</p>
+{% endif %}
+</div>
+{% endblock %}

--- a/scalereg3/reports/templates/reports_sales_dashboard.html
+++ b/scalereg3/reports/templates/reports_sales_dashboard.html
@@ -1,0 +1,77 @@
+{% extends "admin/base_site.html" %}
+
+{% block extrahead %}{{ block.super }}
+<script type="text/javascript" src="/media/scale/js/sorttable.js"></script>
+{% endblock %}
+{% block coltype %}colMS{% endblock %}
+{% block bodyclass %}dashboard{% endblock %}
+{% block content %}
+<div id="content-main">
+
+<script type="text/javascript" language="Javascript">
+function toggleDisplay(id) {
+  const element = document.getElementById(id);
+  if (element.style.display == "none" ) {
+    element.style.display = "block";
+  } else {
+    element.style.display = "none";
+  }
+}
+</script>
+
+<h2>Orders
+<a href="javascript:void(0)" onclick="toggleDisplay('orders')"><tt>[*]</tt></a>
+</h2>
+
+<div id="orders">
+{% if orders %}
+<table border="1">
+<tr>
+  <th></th>
+  <th>7 Days</th>
+  <th>30 Days</th>
+  <th>Total</th>
+</tr>
+<tr>
+  <td>Orders</td>
+  <td>{{ orders.numbers_7 }}</td>
+  <td>{{ orders.numbers_30 }}</td>
+  <td>{{ orders.numbers }}</td>
+</tr>
+<tr>
+  <td>Revenue</td>
+  <td>${{ orders.revenue_7 }}</td>
+  <td>${{ orders.revenue_30 }}</td>
+  <td>${{ orders.revenue }}</td>
+</tr>
+</table>
+
+<h3>By Type
+<a href="javascript:void(0)" onclick="toggleDisplay('orders_type')"><tt>[*]</tt></a>
+</h3>
+
+<div id="orders_type">
+<table border="1" class="sortable">
+<tr>
+  <th>Type</th>
+  <th>7 Days</th>
+  <th>30 Days</th>
+  <th>Total</th>
+  <th>Revenue</th>
+</tr>
+{% for order_pt in orders.by_type %}
+<tr>
+  <td>{{ order_pt.name }}</td>
+  <td>{{ order_pt.numbers_7 }}</td>
+  <td>{{ order_pt.numbers_30 }}</td>
+  <td>{{ order_pt.numbers }}</td>
+  <td>${{ order_pt.revenue }}</td>
+</tr>
+{% endfor %}
+</table>
+</div>
+{% endif %}
+</div>
+
+</div>
+{% endblock %}

--- a/scalereg3/reports/test_views.py
+++ b/scalereg3/reports/test_views.py
@@ -1,0 +1,149 @@
+from decimal import Decimal
+
+from django.apps import apps
+from django.test import TestCase
+from django.utils import timezone
+
+from .views import get_orders_data
+
+
+class GetOrdersDataTest(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        today = timezone.now()
+        day = timezone.timedelta(days=1)
+
+        order_objects = apps.get_model('reg23', 'Order').objects
+        create_order_with_date = cls.create_order_with_date
+        create_order_with_date(order_objects,
+                               today,
+                               order_num='0',
+                               valid=True,
+                               payment_type='cash',
+                               amount=2)
+        create_order_with_date(order_objects,
+                               today - (6 * day),
+                               order_num='1',
+                               valid=True,
+                               payment_type='cash',
+                               amount=3)
+        create_order_with_date(order_objects,
+                               today - (7 * day),
+                               order_num='2',
+                               valid=True,
+                               payment_type='payflow',
+                               amount=5)
+        create_order_with_date(order_objects,
+                               today - (8 * day),
+                               order_num='3',
+                               valid=True,
+                               payment_type='cash',
+                               amount=7)
+        create_order_with_date(order_objects,
+                               today - (29 * day),
+                               order_num='4',
+                               valid=True,
+                               payment_type='payflow',
+                               amount=11)
+        create_order_with_date(order_objects,
+                               today - (30 * day),
+                               order_num='5',
+                               valid=True,
+                               payment_type='cash',
+                               amount=13)
+        create_order_with_date(order_objects,
+                               today - (31 * day),
+                               order_num='6',
+                               valid=True,
+                               payment_type='cash',
+                               amount=17)
+
+        create_order_with_date(order_objects,
+                               today - (2 * day),
+                               order_num='7',
+                               valid=False,
+                               payment_type='cash',
+                               amount=19)
+        create_order_with_date(order_objects,
+                               today - (10 * day),
+                               order_num='8',
+                               valid=False,
+                               payment_type='payflow',
+                               amount=23)
+        create_order_with_date(order_objects,
+                               today - (40 * day),
+                               order_num='9',
+                               valid=False,
+                               payment_type='cash',
+                               amount=29)
+
+    @staticmethod
+    def create_order_with_date(order_objects, date, **kwargs):
+        order = order_objects.create(**kwargs)
+        order.date = date
+        order.save()
+
+    def check_by_type_list(self, actual_list, expected_list):
+        self.assertEqual(len(actual_list), len(expected_list))
+        for actual, expected in zip(actual_list, expected_list):
+            self.assertDictEqual(actual, expected)
+
+    def test_get_orders_data(self):
+        data = get_orders_data()
+        self.assertTrue('by_type' in data)
+        by_type_data = data.pop('by_type')
+        expected_by_type = ({
+            'name': 'Payflow',
+            'numbers': 2,
+            'numbers_30': 2,
+            'numbers_7': 1,
+            'revenue': Decimal('16.00'),
+        }, {
+            'name': 'Cash',
+            'numbers': 5,
+            'numbers_30': 4,
+            'numbers_7': 2,
+            'revenue': Decimal('42.00'),
+        }, {
+            'name': 'Invitee',
+            'numbers': 0,
+            'numbers_30': 0,
+            'numbers_7': 0,
+            'revenue': 0,
+        }, {
+            'name': 'Exhibitor',
+            'numbers': 0,
+            'numbers_30': 0,
+            'numbers_7': 0,
+            'revenue': 0,
+        }, {
+            'name': 'Speaker',
+            'numbers': 0,
+            'numbers_30': 0,
+            'numbers_7': 0,
+            'revenue': 0,
+        }, {
+            'name': 'Press',
+            'numbers': 0,
+            'numbers_30': 0,
+            'numbers_7': 0,
+            'revenue': 0,
+        }, {
+            'name': 'Free Upgrade',
+            'numbers': 0,
+            'numbers_30': 0,
+            'numbers_7': 0,
+            'revenue': 0,
+        })
+        self.check_by_type_list(by_type_data, expected_by_type)
+
+        expected_dict = {
+            'numbers': 7,
+            'numbers_30': 6,
+            'numbers_7': 3,
+            'revenue': Decimal('58.00'),
+            'revenue_30': Decimal('41.00'),
+            'revenue_7': Decimal('10.00'),
+        }
+        self.assertDictEqual(data, expected_dict)

--- a/scalereg3/reports/tests.py
+++ b/scalereg3/reports/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/scalereg3/reports/tests.py
+++ b/scalereg3/reports/tests.py
@@ -1,5 +1,7 @@
+from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.utils import timezone
 
 
 class IndexTest(TestCase):
@@ -23,3 +25,70 @@ class IndexTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response,
                             '<a href="sales_dashboard/">Sales Dashboard</a>')
+
+
+class SalesDashboardTest(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        today = timezone.now()
+        day = timezone.timedelta(days=1)
+
+        order_objects = apps.get_model('reg23', 'Order').objects
+        create_order_with_date = cls.create_order_with_date
+        create_order_with_date(order_objects,
+                               today,
+                               order_num='0',
+                               valid=True,
+                               payment_type='cash',
+                               amount=2)
+        create_order_with_date(order_objects,
+                               today - (8 * day),
+                               order_num='1',
+                               valid=True,
+                               payment_type='payflow',
+                               amount=3)
+        create_order_with_date(order_objects,
+                               today - (31 * day),
+                               order_num='2',
+                               valid=True,
+                               payment_type='cash',
+                               amount=7)
+
+    @staticmethod
+    def create_order_with_date(order_objects, date, **kwargs):
+        order = order_objects.create(**kwargs)
+        order.date = date
+        order.save()
+
+    def test_not_logged_in(self):
+        response = self.client.get('/reports/sales_dashboard/')
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response,
+                             '/admin/login/?next=/reports/sales_dashboard/')
+
+    def test_normal_user_logged_in(self):
+        user = get_user_model().objects.create_user('user', is_staff=False)
+        self.client.force_login(user)
+        response = self.client.get('/reports/sales_dashboard/')
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response,
+                             '/admin/login/?next=/reports/sales_dashboard/')
+
+    def test_staff_user_logged_in(self):
+        user = get_user_model().objects.create_user('user', is_staff=True)
+        self.client.force_login(user)
+        response = self.client.get('/reports/sales_dashboard/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            '<tr><td>Revenue</td><td>$2.00</td><td>$5.00</td><td>$12.00</td></tr>',
+            html=True)
+        self.assertContains(
+            response,
+            '<tr><td>Payflow</td><td>0</td><td>1</td><td>1</td><td>$3.00</td></tr>',
+            html=True)
+        self.assertContains(
+            response,
+            '<tr><td>Cash</td><td>1</td><td>1</td><td>2</td><td>$9.00</td></tr>',
+            html=True)

--- a/scalereg3/reports/tests.py
+++ b/scalereg3/reports/tests.py
@@ -1,3 +1,25 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-# Create your tests here.
+
+class IndexTest(TestCase):
+
+    def test_not_logged_in(self):
+        response = self.client.get('/reports/')
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, '/admin/login/?next=/reports/')
+
+    def test_normal_user_logged_in(self):
+        user = get_user_model().objects.create_user('user', is_staff=False)
+        self.client.force_login(user)
+        response = self.client.get('/reports/')
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, '/admin/login/?next=/reports/')
+
+    def test_staff_user_logged_in(self):
+        user = get_user_model().objects.create_user('user', is_staff=True)
+        self.client.force_login(user)
+        response = self.client.get('/reports/')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response,
+                            '<a href="sales_dashboard/">Sales Dashboard</a>')

--- a/scalereg3/reports/urls.py
+++ b/scalereg3/reports/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path('', views.index),
+]

--- a/scalereg3/reports/urls.py
+++ b/scalereg3/reports/urls.py
@@ -4,4 +4,6 @@ from . import views
 
 urlpatterns = [
     path('', views.index),
+    path('sales_dashboard/', views.sales_dashboard,
+         {'report_name': 'Sales Dashboard'}),
 ]

--- a/scalereg3/reports/views.py
+++ b/scalereg3/reports/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/scalereg3/reports/views.py
+++ b/scalereg3/reports/views.py
@@ -1,7 +1,27 @@
 from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import render
+from django.urls import get_resolver
+from django.urls.resolvers import URLPattern
+
+
+@staff_member_required
+def sales_dashboard(request, report_name):
+    pass
 
 
 @staff_member_required
 def index(request):
-    pass
+    model_list = []
+    for pattern in get_resolver('reports.urls').url_patterns:
+        if not isinstance(pattern, URLPattern):
+            continue
+        name = pattern.default_args.get('report_name', None)
+        if not name:
+            continue
+        model_list.append({'name': name, 'url': pattern.pattern})
+
+    return render(request, 'reports_index.html', {
+        'user': request.user,
+        'title': 'Reports',
+        'model_list': model_list
+    })

--- a/scalereg3/reports/views.py
+++ b/scalereg3/reports/views.py
@@ -1,3 +1,7 @@
+from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import render
 
-# Create your views here.
+
+@staff_member_required
+def index(request):
+    pass

--- a/scalereg3/reports/views.py
+++ b/scalereg3/reports/views.py
@@ -1,12 +1,67 @@
+from django.apps import apps
 from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import render
 from django.urls import get_resolver
 from django.urls.resolvers import URLPattern
+from django.utils import timezone
+
+
+def get_stats_for_orders(orders, postfix=None, with_revenue=True):
+    numbers_key = 'numbers'
+    revenue_key = 'revenue'
+    if postfix:
+        numbers_key += postfix
+        revenue_key += postfix
+
+    results = {}
+    results[numbers_key] = orders.count()
+    if with_revenue:
+        results[revenue_key] = sum(order.amount for order in orders)
+    return results
+
+
+def get_orders_data():
+    today = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    days_30 = today - timezone.timedelta(days=30)
+    days_7 = today - timezone.timedelta(days=7)
+
+    order_model = apps.get_model('reg23', 'Order')
+    orders = order_model.objects.filter(valid=True)
+
+    orders_data = {}
+    orders_data['by_type'] = []
+    orders_data |= get_stats_for_orders(orders)
+    orders_data |= get_stats_for_orders(orders.filter(date__gt=days_30),
+                                        postfix='_30')
+    orders_data |= get_stats_for_orders(orders.filter(date__gt=days_7),
+                                        postfix='_7')
+
+    for payment_choice in order_model.payment_type.field.choices:
+        orders_of_type = orders.filter(payment_type=payment_choice[0])
+
+        data_payment_type = {}
+        data_payment_type['name'] = payment_choice[1]
+        data_payment_type |= get_stats_for_orders(orders_of_type)
+        data_payment_type |= get_stats_for_orders(
+            orders_of_type.filter(date__gt=days_30),
+            postfix='_30',
+            with_revenue=False)
+        data_payment_type |= get_stats_for_orders(
+            orders_of_type.filter(date__gt=days_7),
+            postfix='_7',
+            with_revenue=False)
+
+        orders_data['by_type'].append(data_payment_type)
+
+    return orders_data
 
 
 @staff_member_required
 def sales_dashboard(request, report_name):
-    pass
+    return render(request, 'reports_sales_dashboard.html', {
+        'title': report_name,
+        'orders': get_orders_data(),
+    })
 
 
 @staff_member_required

--- a/scalereg3/scalereg3/settings.py
+++ b/scalereg3/scalereg3/settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'reg23',
+    'reports',
 ]
 
 MIDDLEWARE = [

--- a/scalereg3/scalereg3/urls.py
+++ b/scalereg3/scalereg3/urls.py
@@ -23,6 +23,7 @@ from reg23 import views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('reg23/', include('reg23.urls')),
+    path('reports/', include('reports.urls')),
 
     # Placeholder index page.
     path('', views.index_redirect),

--- a/scalereg3/scalereg3/urls.py
+++ b/scalereg3/scalereg3/urls.py
@@ -15,12 +15,16 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
 from django.urls import include
 from django.urls import path
 
 from reg23 import views
 
 urlpatterns = [
+    path("accounts/login/",
+         auth_views.LoginView.as_view(template_name="admin/login.html")),
+    path("accounts/", include("django.contrib.auth.urls")),
     path('admin/', admin.site.urls),
     path('reg23/', include('reg23.urls')),
     path('reports/', include('reports.urls')),


### PR DESCRIPTION
Port part of the reports dashboard to scalereg3. Instead of having one giant dashboard, use a set of smaller dashboards. Start with the sales dashboard. In order to add this dashboard, first:

1. Add a new reports app.
2. Set up the reports/ index page to auto-populate reports URLs.
3. Set up the accounts/ url.