### PR TITLE
Port express check-in code

### DIFF
--- a/scalereg3/common/tests.py
+++ b/scalereg3/common/tests.py
@@ -7,6 +7,10 @@ from . import utils
 
 class UtilsTest(TestCase):
 
+    def test_checkin_hash(self):
+        self.assertEqual(utils.checkin_hash('abc'), 'a9993e')
+        self.assertEqual(utils.checkin_hash('xyz'), '66b274')
+
     def test_generate_id(self):
         random.seed(0)
         self.assertEqual(utils.generate_id(5), 'Y0CQ6')

--- a/scalereg3/common/utils.py
+++ b/scalereg3/common/utils.py
@@ -1,5 +1,8 @@
+import hashlib
 import random
 import string
+
+from django.conf import settings
 
 
 def generate_id(length):
@@ -13,3 +16,8 @@ def generate_unique_id(length, existing_ids):
         new_id = generate_id(length)
         if new_id not in existing_ids:
             return new_id
+
+
+def checkin_hash(data):
+    data += settings.SCALEREG_EXPRESS_CHECKIN_SECRET
+    return hashlib.sha1(data.encode('utf-8')).hexdigest()[:6]

--- a/scalereg3/reg23/models.py
+++ b/scalereg3/reg23/models.py
@@ -2,6 +2,8 @@ import datetime
 
 from django.db import models
 
+from common import utils
+
 SALUTATION_CHOICES = (
     ('Mr', 'Mr.'),
     ('Ms', 'Ms.'),
@@ -282,6 +284,9 @@ class Attendee(models.Model):
     ordered_items = models.ManyToManyField(Item, blank=True)
     can_email = models.BooleanField(default=False)
     answers = models.ManyToManyField(Answer, blank=True)
+
+    def checkin_code(self):
+        return f'{self.id:04d}{utils.checkin_hash(self.full_name())}'
 
     def full_name(self):
         return f'{self.first_name} {self.last_name}'

--- a/scalereg3/reg23/test_models.py
+++ b/scalereg3/reg23/test_models.py
@@ -73,6 +73,22 @@ class TicketCostTest(TestCase):
         self.assertEqual(cost, 20)
 
 
+class AttendeeCheckinCodeTest(TestCase):
+
+    def test_name(self):
+        ticket = Ticket.objects.create(name='T1',
+                                       description='T1',
+                                       ticket_type='full',
+                                       price=10,
+                                       public=True,
+                                       cash=False,
+                                       upgradable=False)
+        attendee = Attendee.objects.create(badge_type=ticket,
+                                           first_name='Foo',
+                                           last_name='Bar Qux')
+        self.assertEqual(attendee.checkin_code(), '00018d4d7f')
+
+
 class AttendeeFullNameTest(TestCase):
 
     def test_name(self):

--- a/scalereg3/reg23/test_views.py
+++ b/scalereg3/reg23/test_views.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
-from .models import Item
-from .views import get_posted_items
+from .models import Attendee, Item, Ticket
+from .views import generate_notify_attendee_body, get_posted_items
 
 
 class GetPostedItemsTest(TestCase):
@@ -83,3 +83,32 @@ class GetPostedItemsTest(TestCase):
         selected_items = get_posted_items(post, avail_items)
         self.assertEqual(len(selected_items), 1)
         self.assertIn(self.item1, selected_items)
+
+
+class GenerateNotifyAttendeeBodyTest(TestCase):
+
+    def test_generate_body(self):
+        ticket = Ticket.objects.create(name='T1',
+                                       description='Ticket 1',
+                                       price=100,
+                                       public=True,
+                                       cash=False,
+                                       upgradable=False,
+                                       ticket_type='full')
+        attendee = Attendee.objects.create(first_name='Test',
+                                           last_name='User II',
+                                           email='a@b.com',
+                                           zip_code='12345',
+                                           badge_type=ticket)
+
+        expected = '''Thank you for registering for SCALE.
+The details of your registration are included below.
+
+First Name: Test
+Last Name: User II
+Email: a@b.com
+Zip Code: 12345
+
+Badge Type: Ticket 1
+'''
+        self.assertEqual(generate_notify_attendee_body(attendee), expected)

--- a/scalereg3/reg23/test_views.py
+++ b/scalereg3/reg23/test_views.py
@@ -104,11 +104,15 @@ class GenerateNotifyAttendeeBodyTest(TestCase):
         expected = '''Thank you for registering for SCALE.
 The details of your registration are included below.
 
+Please note the Express Check-In Code below, which will allow you to
+speed up your check-in and badge pickup on-site.
+
 First Name: Test
 Last Name: User II
 Email: a@b.com
 Zip Code: 12345
 
 Badge Type: Ticket 1
+Express Check-In Code: 0001cf7b36
 '''
         self.assertEqual(generate_notify_attendee_body(attendee), expected)

--- a/scalereg3/reg23/views.py
+++ b/scalereg3/reg23/views.py
@@ -169,12 +169,16 @@ def generate_notify_attendee_body(attendee):
     return f'''Thank you for registering for SCALE.
 The details of your registration are included below.
 
+Please note the Express Check-In Code below, which will allow you to
+speed up your check-in and badge pickup on-site.
+
 First Name: {attendee.first_name}
 Last Name: {attendee.last_name}
 Email: {attendee.email}
 Zip Code: {attendee.zip_code}
 
 Badge Type: {attendee.badge_type.description}
+Express Check-In Code: {attendee.checkin_code()}
 '''
 
 

--- a/scalereg3/reg23/views.py
+++ b/scalereg3/reg23/views.py
@@ -165,17 +165,8 @@ def start_payment_search_for_attendee(id_str, email_str):
     return attendee
 
 
-def notify_attendee(attendee):
-    if not settings.SCALEREG_SEND_MAIL:
-        return
-
-    if (not attendee.email or attendee.email.endswith('@example.com')
-            or attendee.email.endswith('@none.com')
-            or '@' not in attendee.email):
-        return
-
-    subject = 'SCALE Registration'
-    body = f'''Thank you for registering for SCALE.
+def generate_notify_attendee_body(attendee):
+    return f'''Thank you for registering for SCALE.
 The details of your registration are included below.
 
 First Name: {attendee.first_name}
@@ -186,8 +177,19 @@ Zip Code: {attendee.zip_code}
 Badge Type: {attendee.badge_type.description}
 '''
 
+
+def notify_attendee(attendee):
+    if not settings.SCALEREG_SEND_MAIL:
+        return
+
+    if (not attendee.email or attendee.email.endswith('@example.com')
+            or attendee.email.endswith('@none.com')
+            or '@' not in attendee.email):
+        return
+
+    subject = 'SCALE Registration'
     send_mail(subject,
-              body,
+              generate_notify_attendee_body(attendee),
               settings.SCALEREG_EMAIL, [attendee.email],
               fail_silently=True)
 

--- a/scalereg3/scalereg3/settings.py
+++ b/scalereg3/scalereg3/settings.py
@@ -130,6 +130,9 @@ SCALEREG_PAYFLOW_LOGIN = ''
 # Partner (either Paypal or Verisign):
 SCALEREG_PAYFLOW_PARTNER = ''
 
+# Secret used for express check-in and scanned badges.
+SCALEREG_EXPRESS_CHECKIN_SECRET = ''
+
 # Set to True if you want scalereg to be able to email attendees.
 # You need to set EMAIL_HOST, EMAIL_PORT, and other EMAIL_ settings
 # appropriately.


### PR DESCRIPTION
Port the express check-in code from reg6 to reg23, so attendees can get the code in their confirmation emails when they register.