### PR TITLE
Apply promos on start_payment and payment pages

### DIFF
--- a/scalereg3/reg23/models.py
+++ b/scalereg3/reg23/models.py
@@ -134,7 +134,7 @@ class Ticket(models.Model):
 
     def apply_promo(self, promo):
         if promo and promo.is_applicable_to(self):
-            self.price *= promo.price_modifier
+            self.price = round(self.price * promo.price_modifier, 2)
 
 
 class PromoCodeManager(models.Manager):
@@ -210,7 +210,7 @@ class Item(models.Model):
 
     def apply_promo(self, promo):
         if promo and self.promo:
-            self.price *= promo.price_modifier
+            self.price = round(self.price * promo.price_modifier, 2)
 
 
 class Answer(models.Model):

--- a/scalereg3/reg23/test_models.py
+++ b/scalereg3/reg23/test_models.py
@@ -6,6 +6,7 @@ from .models import Answer
 from .models import Attendee
 from .models import Item
 from .models import PendingOrder
+from .models import PromoCode
 from .models import Question
 from .models import Ticket
 
@@ -21,6 +22,12 @@ class TicketCostTest(TestCase):
                                            public=True,
                                            cash=False,
                                            upgradable=False)
+        cls.promo = PromoCode.objects.create(
+            name='P1',
+            description='P1 all',
+            price_modifier=decimal.Decimal(0.6),
+            active=True,
+            applies_to_all=True)
         cls.item1 = Item.objects.create(name='I1',
                                         description='Item 1',
                                         price=decimal.Decimal(17),
@@ -32,7 +39,7 @@ class TicketCostTest(TestCase):
                                         description='Item 2',
                                         price=decimal.Decimal(6),
                                         active=True,
-                                        promo=False,
+                                        promo=True,
                                         ticket_offset=False,
                                         applies_to_all=True)
         cls.item3 = Item.objects.create(name='I3',
@@ -46,33 +53,45 @@ class TicketCostTest(TestCase):
                                         description='Ticket offset 1',
                                         price=decimal.Decimal(19),
                                         active=True,
-                                        promo=False,
+                                        promo=True,
                                         ticket_offset=True,
                                         applies_to_all=True)
 
     def test_no_items(self):
-        cost = self.ticket.ticket_cost([])
+        cost = self.ticket.ticket_cost([], None)
         self.assertEqual(cost, 10)
+        cost = self.ticket.ticket_cost([], self.promo)
+        self.assertEqual(cost, 6)
 
     def test_single_item(self):
-        cost = self.ticket.ticket_cost([self.item1])
+        cost = self.ticket.ticket_cost([self.item1], None)
         self.assertEqual(cost, 27)
+        cost = self.ticket.ticket_cost([self.item1], self.promo)
+        self.assertEqual(cost, 23)
 
     def test_multiple_items(self):
-        cost = self.ticket.ticket_cost([self.item1, self.item2])
+        cost = self.ticket.ticket_cost([self.item1, self.item2], None)
         self.assertEqual(cost, 33)
+        cost = self.ticket.ticket_cost([self.item1, self.item2], self.promo)
+        self.assertAlmostEqual(cost, decimal.Decimal(26.60))
 
     def test_with_ticket_offset_item(self):
-        cost = self.ticket.ticket_cost([self.item3])
+        cost = self.ticket.ticket_cost([self.item3], None)
+        self.assertEqual(cost, 14)
+        cost = self.ticket.ticket_cost([self.item3], self.promo)
         self.assertEqual(cost, 14)
 
     def test_with_two_ticket_offset_items(self):
-        cost = self.ticket.ticket_cost([self.item3, self.item4])
+        cost = self.ticket.ticket_cost([self.item3, self.item4], None)
         self.assertEqual(cost, 33)
+        cost = self.ticket.ticket_cost([self.item3, self.item4], self.promo)
+        self.assertAlmostEqual(cost, decimal.Decimal(25.40))
 
     def test_with_regular_item_and_ticket_offset_item(self):
-        cost = self.ticket.ticket_cost([self.item2, self.item3])
+        cost = self.ticket.ticket_cost([self.item2, self.item3], None)
         self.assertEqual(cost, 20)
+        cost = self.ticket.ticket_cost([self.item2, self.item3], self.promo)
+        self.assertAlmostEqual(cost, decimal.Decimal(17.60))
 
 
 class AttendeeCheckinCodeTest(TestCase):
@@ -119,7 +138,7 @@ class AttendeeTicketCostTest(TestCase):
                                        cash=False,
                                        upgradable=False)
         cls.item1 = Item.objects.create(name='I1',
-                                        description='Promo',
+                                        description='No promo item',
                                         price=decimal.Decimal(17),
                                         active=True,
                                         promo=False,
@@ -135,6 +154,66 @@ class AttendeeTicketCostTest(TestCase):
     def test_item_no_promo(self):
         self.attendee.ordered_items.add(self.item1)
         self.assertEqual(self.attendee.ticket_cost(), 27)
+
+
+class AttendeeTicketCostWithPromoTest(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        ticket = Ticket.objects.create(name='T1',
+                                       description='T1',
+                                       ticket_type='full',
+                                       price=decimal.Decimal(10),
+                                       public=True,
+                                       cash=False,
+                                       upgradable=False)
+        promo = PromoCode.objects.create(name='P1',
+                                         description='P1 all',
+                                         price_modifier=decimal.Decimal(0.6),
+                                         active=True,
+                                         applies_to_all=True)
+        cls.item1 = Item.objects.create(name='I1',
+                                        description='No promo item',
+                                        price=decimal.Decimal(17),
+                                        active=True,
+                                        promo=False,
+                                        ticket_offset=False,
+                                        applies_to_all=True)
+        cls.item2 = Item.objects.create(name='I2',
+                                        description='Promo item',
+                                        price=decimal.Decimal(30),
+                                        active=True,
+                                        promo=True,
+                                        ticket_offset=False,
+                                        applies_to_all=True)
+        cls.attendee = Attendee.objects.create(badge_type=ticket,
+                                               first_name='Foo',
+                                               last_name='Bar',
+                                               promo=promo)
+
+    def test_no_items(self):
+        self.assertEqual(self.attendee.ticket_cost(), 6)
+        # Make sure there are no side effects in the previous call.
+        self.assertEqual(self.attendee.ticket_cost(), 6)
+
+    def test_item_no_promo(self):
+        self.attendee.ordered_items.add(self.item1)
+        self.assertEqual(self.attendee.ticket_cost(), 23)
+        # Make sure there are no side effects in the previous call.
+        self.assertEqual(self.attendee.ticket_cost(), 23)
+
+    def test_item_promo(self):
+        self.attendee.ordered_items.add(self.item2)
+        self.assertEqual(self.attendee.ticket_cost(), 24)
+        # Make sure there are no side effects in the previous call.
+        self.assertEqual(self.attendee.ticket_cost(), 24)
+
+    def test_items(self):
+        self.attendee.ordered_items.add(self.item1)
+        self.attendee.ordered_items.add(self.item2)
+        self.assertEqual(self.attendee.ticket_cost(), 41)
+        # Make sure there are no side effects in the previous call.
+        self.assertEqual(self.attendee.ticket_cost(), 41)
 
 
 class PendingOrderTest(TestCase):

--- a/scalereg3/reg23/test_models.py
+++ b/scalereg3/reg23/test_models.py
@@ -1,3 +1,5 @@
+import decimal
+
 from django.test import TestCase
 
 from .models import Answer
@@ -15,34 +17,34 @@ class TicketCostTest(TestCase):
         cls.ticket = Ticket.objects.create(name='T1',
                                            description='T1',
                                            ticket_type='full',
-                                           price=10,
+                                           price=decimal.Decimal(10),
                                            public=True,
                                            cash=False,
                                            upgradable=False)
         cls.item1 = Item.objects.create(name='I1',
                                         description='Item 1',
-                                        price=17,
+                                        price=decimal.Decimal(17),
                                         active=True,
                                         promo=False,
                                         ticket_offset=False,
                                         applies_to_all=True)
         cls.item2 = Item.objects.create(name='I2',
                                         description='Item 2',
-                                        price=6,
+                                        price=decimal.Decimal(6),
                                         active=True,
                                         promo=False,
                                         ticket_offset=False,
                                         applies_to_all=True)
         cls.item3 = Item.objects.create(name='I3',
                                         description='Ticket offset 1',
-                                        price=14,
+                                        price=decimal.Decimal(14),
                                         active=True,
                                         promo=False,
                                         ticket_offset=True,
                                         applies_to_all=True)
         cls.item4 = Item.objects.create(name='I4',
                                         description='Ticket offset 1',
-                                        price=19,
+                                        price=decimal.Decimal(19),
                                         active=True,
                                         promo=False,
                                         ticket_offset=True,
@@ -79,7 +81,7 @@ class AttendeeCheckinCodeTest(TestCase):
         ticket = Ticket.objects.create(name='T1',
                                        description='T1',
                                        ticket_type='full',
-                                       price=10,
+                                       price=decimal.Decimal(10),
                                        public=True,
                                        cash=False,
                                        upgradable=False)
@@ -95,7 +97,7 @@ class AttendeeFullNameTest(TestCase):
         ticket = Ticket.objects.create(name='T1',
                                        description='T1',
                                        ticket_type='full',
-                                       price=10,
+                                       price=decimal.Decimal(10),
                                        public=True,
                                        cash=False,
                                        upgradable=False)
@@ -112,13 +114,13 @@ class AttendeeTicketCostTest(TestCase):
         ticket = Ticket.objects.create(name='T1',
                                        description='T1',
                                        ticket_type='full',
-                                       price=10,
+                                       price=decimal.Decimal(10),
                                        public=True,
                                        cash=False,
                                        upgradable=False)
         cls.item1 = Item.objects.create(name='I1',
                                         description='Promo',
-                                        price=17,
+                                        price=decimal.Decimal(17),
                                         active=True,
                                         promo=False,
                                         ticket_offset=False,
@@ -153,13 +155,13 @@ class QuestionTest(TestCase):
         cls.ticket1 = Ticket.objects.create(name='T1',
                                             description='T1',
                                             ticket_type='full',
-                                            price=10,
+                                            price=decimal.Decimal(10),
                                             public=True,
                                             cash=False,
                                             upgradable=False)
         cls.item1 = Item.objects.create(name='I1',
                                         description='Item 1',
-                                        price=17,
+                                        price=decimal.Decimal(17),
                                         active=True,
                                         promo=False,
                                         ticket_offset=False,
@@ -191,7 +193,7 @@ class QuestionTest(TestCase):
         ticket2 = Ticket.objects.create(name='T2',
                                         description='T2',
                                         ticket_type='expo',
-                                        price=5,
+                                        price=decimal.Decimal(5),
                                         public=True,
                                         cash=False,
                                         upgradable=False)
@@ -205,7 +207,7 @@ class QuestionTest(TestCase):
     def test_is_applicable_to_item(self):
         item2 = Item.objects.create(name='I2',
                                     description='Item 2',
-                                    price=6,
+                                    price=decimal.Decimal(6),
                                     active=True,
                                     promo=False,
                                     ticket_offset=False,

--- a/scalereg3/reg23/test_views.py
+++ b/scalereg3/reg23/test_views.py
@@ -1,3 +1,5 @@
+import decimal
+
 from django.test import TestCase
 
 from .models import Attendee, Item, Ticket
@@ -10,21 +12,21 @@ class GetPostedItemsTest(TestCase):
     def setUpTestData(cls):
         cls.item1 = Item.objects.create(name='I1',
                                         description='Item 1',
-                                        price=10,
+                                        price=decimal.Decimal(10),
                                         active=True,
                                         promo=False,
                                         ticket_offset=False,
                                         applies_to_all=True)
         cls.item2 = Item.objects.create(name='I2',
                                         description='Item 2',
-                                        price=20,
+                                        price=decimal.Decimal(20),
                                         active=True,
                                         promo=False,
                                         ticket_offset=False,
                                         applies_to_all=True)
         cls.item3 = Item.objects.create(name='I3',
                                         description='Item 3',
-                                        price=30,
+                                        price=decimal.Decimal(30),
                                         active=False,
                                         promo=False,
                                         ticket_offset=False,
@@ -90,7 +92,7 @@ class GenerateNotifyAttendeeBodyTest(TestCase):
     def test_generate_body(self):
         ticket = Ticket.objects.create(name='T1',
                                        description='Ticket 1',
-                                       price=100,
+                                       price=decimal.Decimal(100),
                                        public=True,
                                        cash=False,
                                        upgradable=False,

--- a/scalereg3/reg23/tests.py
+++ b/scalereg3/reg23/tests.py
@@ -250,7 +250,7 @@ class IndexTestWithPromo(TestCase):
                             count=1,
                             html=True)
         self.assertContains(response,
-                            '<label for="ticket_T2">$3.67</label>',
+                            '<label for="ticket_T2">$3.68</label>',
                             count=1,
                             html=True)
 

--- a/scalereg3/reg23/tests.py
+++ b/scalereg3/reg23/tests.py
@@ -1,4 +1,5 @@
 import datetime
+import decimal
 import random
 
 from django.test import TestCase
@@ -29,7 +30,7 @@ class IndexTest(TestCase):
         Ticket.objects.create(name='T1',
                               description='T1 full',
                               ticket_type='full',
-                              price=10,
+                              price=decimal.Decimal(10),
                               public=True,
                               cash=False,
                               upgradable=False,
@@ -38,21 +39,21 @@ class IndexTest(TestCase):
         Ticket.objects.create(name='T2',
                               description='T2 expo',
                               ticket_type='expo',
-                              price=5.25,
+                              price=decimal.Decimal(5.25),
                               public=True,
                               cash=False,
                               upgradable=False)
         Ticket.objects.create(name='T3',
                               description='T3 press',
                               ticket_type='press',
-                              price=0,
+                              price=decimal.Decimal(0),
                               public=False,
                               cash=False,
                               upgradable=False)
         Ticket.objects.create(name='T4',
                               description='T4 past',
                               ticket_type='expo',
-                              price=4.00,
+                              price=decimal.Decimal(4.00),
                               public=True,
                               cash=False,
                               upgradable=False,
@@ -60,7 +61,7 @@ class IndexTest(TestCase):
         Ticket.objects.create(name='T5',
                               description='T5 future',
                               ticket_type='expo',
-                              price=6.00,
+                              price=decimal.Decimal(6.00),
                               public=True,
                               cash=False,
                               upgradable=False,
@@ -144,7 +145,7 @@ class IndexTestWithPromo(TestCase):
         Ticket.objects.create(name='T1',
                               description='T1 full',
                               ticket_type='full',
-                              price=10,
+                              price=decimal.Decimal(10),
                               public=True,
                               cash=False,
                               upgradable=False,
@@ -153,37 +154,38 @@ class IndexTestWithPromo(TestCase):
         ticket2_expo = Ticket.objects.create(name='T2',
                                              description='T2 expo',
                                              ticket_type='expo',
-                                             price=5.25,
+                                             price=decimal.Decimal(5.25),
                                              public=True,
                                              cash=False,
                                              upgradable=False)
         PromoCode.objects.create(name='P1',
                                  description='P1 all',
-                                 price_modifier=0.5,
+                                 price_modifier=decimal.Decimal(0.5),
                                  active=True,
                                  applies_to_all=True)
         PromoCode.objects.create(name='P2',
                                  description='P2 inactive',
-                                 price_modifier=0.5,
+                                 price_modifier=decimal.Decimal(0.5),
                                  active=False,
                                  applies_to_all=True)
         PromoCode.objects.create(name='P3',
                                  description='P3 past',
-                                 price_modifier=0.5,
+                                 price_modifier=decimal.Decimal(0.5),
                                  active=True,
                                  end_date=today,
                                  applies_to_all=True)
         PromoCode.objects.create(name='P4',
                                  description='P4 future',
-                                 price_modifier=0.5,
+                                 price_modifier=decimal.Decimal(0.5),
                                  active=True,
                                  start_date=today + day,
                                  applies_to_all=True)
-        promo5_expo_only = PromoCode.objects.create(name='P5',
-                                                    description='P5 expo only',
-                                                    price_modifier=0.7,
-                                                    active=True,
-                                                    applies_to_all=False)
+        promo5_expo_only = PromoCode.objects.create(
+            name='P5',
+            description='P5 expo only',
+            price_modifier=decimal.Decimal(0.7),
+            active=True,
+            applies_to_all=False)
         promo5_expo_only.applies_to.add(ticket2_expo)
 
     def test_ticket_prices_with_promo(self):
@@ -304,27 +306,27 @@ class ItemsTest(TestCase):
         ticket1_full = Ticket.objects.create(name='T1',
                                              description='T1 full',
                                              ticket_type='full',
-                                             price=10,
+                                             price=decimal.Decimal(10),
                                              public=True,
                                              cash=False,
                                              upgradable=False)
         Ticket.objects.create(name='T2',
                               description='T2 expo',
                               ticket_type='expo',
-                              price=5.25,
+                              price=decimal.Decimal(5.25),
                               public=True,
                               cash=False,
                               upgradable=False)
         Item.objects.create(name='I1',
                             description='For all item',
-                            price=17,
+                            price=decimal.Decimal(17),
                             active=True,
                             promo=False,
                             ticket_offset=False,
                             applies_to_all=True)
         item2_full_only = Item.objects.create(name='I2',
                                               description='Full only item',
-                                              price=16,
+                                              price=decimal.Decimal(16),
                                               active=True,
                                               promo=False,
                                               ticket_offset=False,
@@ -332,7 +334,7 @@ class ItemsTest(TestCase):
         item2_full_only.applies_to.add(ticket1_full)
         Item.objects.create(name='I3',
                             description='Inactive item',
-                            price=15,
+                            price=decimal.Decimal(15),
                             active=False,
                             promo=False,
                             ticket_offset=False,
@@ -499,36 +501,37 @@ class ItemsTestWithPromo(TestCase):
         Ticket.objects.create(name='T1',
                               description='T1 full',
                               ticket_type='full',
-                              price=10,
+                              price=decimal.Decimal(10),
                               public=True,
                               cash=False,
                               upgradable=False)
         ticket2_expo = Ticket.objects.create(name='T2',
                                              description='T2 expo',
                                              ticket_type='expo',
-                                             price=5.25,
+                                             price=decimal.Decimal(5.25),
                                              public=True,
                                              cash=False,
                                              upgradable=False)
         Item.objects.create(name='I1',
                             description='Applies to promo',
-                            price=17,
+                            price=decimal.Decimal(17),
                             active=True,
                             promo=True,
                             ticket_offset=False,
                             applies_to_all=True)
         Item.objects.create(name='I2',
                             description='Does not apply to promo',
-                            price=16.11,
+                            price=decimal.Decimal(16.11),
                             active=True,
                             promo=False,
                             ticket_offset=False,
                             applies_to_all=True)
-        promo1_expo_only = PromoCode.objects.create(name='P1',
-                                                    description='P1 expo only',
-                                                    price_modifier=0.5,
-                                                    active=True,
-                                                    applies_to_all=False)
+        promo1_expo_only = PromoCode.objects.create(
+            name='P1',
+            description='P1 expo only',
+            price_modifier=decimal.Decimal(0.5),
+            active=True,
+            applies_to_all=False)
         promo1_expo_only.applies_to.add(ticket2_expo)
 
     def test_full_ticket_with_promo(self):
@@ -681,7 +684,7 @@ class AttendeeTest(TestCase):
         Ticket.objects.create(name='T1',
                               description='T1 full',
                               ticket_type='full',
-                              price=10,
+                              price=decimal.Decimal(10),
                               public=True,
                               cash=False,
                               upgradable=False,
@@ -690,20 +693,20 @@ class AttendeeTest(TestCase):
         Ticket.objects.create(name='T2',
                               description='T2 expo',
                               ticket_type='expo',
-                              price=5.25,
+                              price=decimal.Decimal(5.25),
                               public=True,
                               cash=False,
                               upgradable=False)
         Item.objects.create(name='I1',
                             description='The item',
-                            price=6.77,
+                            price=decimal.Decimal(6.77),
                             active=True,
                             promo=False,
                             ticket_offset=False,
                             applies_to_all=True)
         Item.objects.create(name='I2',
                             description='The offset item',
-                            price=99.99,
+                            price=decimal.Decimal(99.99),
                             active=True,
                             promo=False,
                             ticket_offset=True,
@@ -1152,36 +1155,37 @@ class AttendeeTestWithPromo(TestCase):
         Ticket.objects.create(name='T1',
                               description='T1 full',
                               ticket_type='full',
-                              price=10,
+                              price=decimal.Decimal(10),
                               public=True,
                               cash=False,
                               upgradable=False)
         ticket2_expo = Ticket.objects.create(name='T2',
                                              description='T2 expo',
                                              ticket_type='expo',
-                                             price=5.25,
+                                             price=decimal.Decimal(5.25),
                                              public=True,
                                              cash=False,
                                              upgradable=False)
         Item.objects.create(name='I1',
                             description='Applies to promo',
-                            price=17,
+                            price=decimal.Decimal(17),
                             active=True,
                             promo=True,
                             ticket_offset=False,
                             applies_to_all=True)
         Item.objects.create(name='I2',
                             description='Does not apply to promo',
-                            price=16.11,
+                            price=decimal.Decimal(16.11),
                             active=True,
                             promo=False,
                             ticket_offset=False,
                             applies_to_all=True)
-        promo1_expo_only = PromoCode.objects.create(name='P1',
-                                                    description='P1 expo only',
-                                                    price_modifier=0.5,
-                                                    active=True,
-                                                    applies_to_all=False)
+        promo1_expo_only = PromoCode.objects.create(
+            name='P1',
+            description='P1 expo only',
+            price_modifier=decimal.Decimal(0.5),
+            active=True,
+            applies_to_all=False)
         promo1_expo_only.applies_to.add(ticket2_expo)
 
     def test_full_ticket_with_promo(self):
@@ -1320,7 +1324,7 @@ class RegisteredAttendeeTest(TestCase):
         t = Ticket.objects.create(name='T1',
                                   description='T1 full',
                                   ticket_type='full',
-                                  price=10,
+                                  price=decimal.Decimal(10),
                                   public=True,
                                   cash=False,
                                   upgradable=False)
@@ -1372,7 +1376,7 @@ class StartPaymentTest(TestCase):
         t = Ticket.objects.create(name='T1',
                                   description='T1 full',
                                   ticket_type='full',
-                                  price=10,
+                                  price=decimal.Decimal(10),
                                   public=True,
                                   cash=False,
                                   upgradable=False)
@@ -1545,7 +1549,7 @@ class PaymentTest(TestCase):
         t = Ticket.objects.create(name='T1',
                                   description='T1 full',
                                   ticket_type='full',
-                                  price=10,
+                                  price=decimal.Decimal(10),
                                   public=True,
                                   cash=False,
                                   upgradable=False)
@@ -1653,7 +1657,7 @@ class SaleTest(TestCase):
         t = Ticket.objects.create(name='T1',
                                   description='T1 full',
                                   ticket_type='full',
-                                  price=10,
+                                  price=decimal.Decimal(10),
                                   public=True,
                                   cash=False,
                                   upgradable=False)
@@ -1818,7 +1822,7 @@ class FinishPaymentTest(TestCase):
         t = Ticket.objects.create(name='T1',
                                   description='T1 full',
                                   ticket_type='full',
-                                  price=10,
+                                  price=decimal.Decimal(10),
                                   public=True,
                                   cash=False,
                                   upgradable=False)
@@ -1889,7 +1893,7 @@ class RegLookupTest(TestCase):
         t = Ticket.objects.create(name='T1',
                                   description='T1 full',
                                   ticket_type='full',
-                                  price=10,
+                                  price=decimal.Decimal(10),
                                   public=True,
                                   cash=False,
                                   upgradable=False)

--- a/scalereg3/reg23/views.py
+++ b/scalereg3/reg23/views.py
@@ -342,7 +342,7 @@ def add_attendee(request):
 
     offset_items = [item for item in items if item.ticket_offset]
     offset_item = offset_items[0] if offset_items else None
-    total = ticket.ticket_cost(items)
+    total = ticket.ticket_cost(items, None)
 
     if action == 'add_new':
         request.session[ATTENDEE_COOKIE] = ''


### PR DESCRIPTION
Fix an issue where the start_payment and payment pages did not apply promo codes.