### PR TITLE
reg23: Fix incorrect fieldsets entries in AttendeeAdmin

### DIFF
--- a/scalereg3/reg23/admin.py
+++ b/scalereg3/reg23/admin.py
@@ -31,11 +31,8 @@ class AttendeeAdmin(admin.ModelAdmin):
         ('Badge Info', {
             'fields': ('badge_type', 'valid', 'checked_in')
         }),
-        ('Items', {
-            'fields': ('ordered_items', 'obtained_items')
-        }),
         ('Misc', {
-            'fields': ('promo', 'order', 'answers')
+            'fields': ('promo', 'order', 'ordered_items', 'answers')
         }),
     )
     list_display = ('id', 'first_name', 'last_name', 'email', 'zip_code',

--- a/scalereg3/reg23/test_admin.py
+++ b/scalereg3/reg23/test_admin.py
@@ -1,8 +1,23 @@
 from django.contrib.admin.sites import AdminSite
 from django.test import TestCase
 
+from .admin import AttendeeAdmin
 from .admin import OrderAdmin
+from .models import Attendee
 from .models import Order
+
+
+class AttendeeAdminTest(TestCase):
+
+    def setUp(self):
+        site = AdminSite()
+        self.admin = AttendeeAdmin(Attendee, site)
+
+    def test_fieldsets(self):
+        form = self.admin.get_form(self.client.request)()
+        self.assertIn('first_name', form.fields)
+        self.assertIn('last_name', form.fields)
+        self.assertIn('ordered_items', form.fields)
 
 
 class OrderAdminTest(TestCase):


### PR DESCRIPTION
Delete obtained_items that existed in reg6 but is not in reg23.